### PR TITLE
Check parent anchor in default trigger

### DIFF
--- a/src/utils/DefaultTrigger.js
+++ b/src/utils/DefaultTrigger.js
@@ -1,3 +1,13 @@
+const getAnchor = (ele) => {
+  let checkingEle = ele;
+  while (!(checkingEle instanceof HTMLAnchorElement)) {
+    const parent = checkingEle.parentElement;
+    if (!parent) return null;
+    checkingEle = parent;
+  }
+  return checkingEle;
+};
+
 export default class DefaultTrigger {
   pjax;
 
@@ -10,10 +20,9 @@ export default class DefaultTrigger {
 
   /**
    * @param {Event} event
+   * @param {HTMLAnchorElement} anchor
    */
-  onAnchorOpen(event) {
-    const { target } = event;
-
+  onAnchorOpen(event, anchor) {
     if (event.defaultPrevented) return;
 
     if (event instanceof MouseEvent || event instanceof KeyboardEvent) {
@@ -22,22 +31,24 @@ export default class DefaultTrigger {
 
     // External.
     // loadURL checks external but without browsers' attribute related support.
-    if (target.origin !== window.location.origin) return;
+    if (anchor.origin !== window.location.origin) return;
 
     event.preventDefault();
 
-    this.pjax.loadURL(event.target.href).catch(() => {});
+    this.pjax.loadURL(anchor.href).catch(() => {});
   }
 
   register() {
     document.addEventListener('click', (event) => {
-      if (!(event.target instanceof HTMLAnchorElement)) return;
-      this.onAnchorOpen(event);
+      const anchor = getAnchor(event.target);
+      if (!anchor) return;
+      this.onAnchorOpen(event, anchor);
     });
     document.addEventListener('keyup', (event) => {
-      if (!(event.target instanceof HTMLAnchorElement)) return;
       if (event.key !== 'Enter') return;
-      this.onAnchorOpen(event);
+      const anchor = getAnchor(event.target);
+      if (!anchor) return;
+      this.onAnchorOpen(event, anchor);
     });
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If an `<a>` tag contains other element, it may not trigger Pjax's default trigger as the trigger only checks `event.target`. Now, let it check the parent, too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In [sliphua.work/categories/Web-Teaser/](https://sliphua.work/categories/Web-Teaser/), click events fire from the `<span>`, now it works fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
