### PR TITLE
Prepare page before complete and success events

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ pjax.weakLoadURL('/your-url')
 
 This method accepts the URL string of the target document, set up the fetch timeout, and sends the request with Pjax headers. It also takes the responsibility of firing Pjax related events.
 
-It returns a promise that resolves after the DOM switch has done, which includes:
+It returns a promise that resolves when all the following steps have done:
 
 - Switch elements selected by `selectors` option.
 - Call `pushState` to update the URL.

--- a/README.md
+++ b/README.md
@@ -248,37 +248,15 @@ pjax.weakLoadURL('/your-url')
 
 ### `switchDOM(url, [overrideOptions])`
 
-This method accepts the URL string of the target document, set up the fetch timeout, and sends the request with Pjax headers. It also takes the responsibility of firing Pjax related events and calling `pushState` to update the URL.
+This method accepts the URL string of the target document, set up the fetch timeout, and sends the request with Pjax headers. It also takes the responsibility of firing Pjax related events.
 
-It returns a promise that resolves with an object of the following properties:
+It returns a promise that resolves after the DOM switch has done, which includes:
 
-- `focusCleared` (Boolean): Indicate that if the focus element of the document has been cleared.
-- `outcomes` (Array): An array of each switch callback's return or fulfilled (for promise) value.
-
-If you want to fetch and process the data on your own, override the implementation while keeping:
-
-- [integrated](https://dom.spec.whatwg.org/#abortcontroller-api-integration) with `abortController` property of the Pjax instance.
-- the resolve object structure.
-
-Code below shows an extendable example:
-
-```js
-const pjax = new Pjax();
-
-pjax.switchDOM = async function customSwitch(url) {
-  const res = await fetch(url, {
-    signal: this.abortController.signal,
-  });
-  // `Body.text` integrates with the fetch signal natively.
-  const newDocument = new DOMParser().parseFromString(await res.text());
-  document.body.replaceWith(newDocument.body);
-  window.history.pushState({}, document.title, res.url);
-  return {
-    focusCleared: true,
-    outcomes: [],
-  };
-};
-```
+- Switch elements selected by `selectors` option.
+- Call `pushState` to update the URL.
+- Focus the first [`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) if previous focus has gone.
+- Execute scripts newly-loaded or targeted by `scripts` option.
+- Scroll to position given by `scrollTo` option.
 
 ### `reload()`
 
@@ -377,14 +355,14 @@ const customSwitch = (oldEle, newEle) => {
 CSS selector used to target scripts to re-execute at page switches. If needing multiple specific selectors, separate them by a comma. Like:
 
 ```js
-// Single element
+// Single selector
 const pjax = new Pjax({
   scripts: 'script.pjax',
 });
 ```
 
 ```js
-// Multiple elements
+// Multiple selectors
 const pjax = new Pjax({
   scripts: 'script.pjax, script.analytics',
 });

--- a/src/__tests__/switchDOM.js
+++ b/src/__tests__/switchDOM.js
@@ -30,6 +30,8 @@ class SimplePjax {
   fire = () => {};
 
   switchDOM = switchDOM;
+
+  preparePage = () => {};
 }
 
 test('partial document response', async () => {

--- a/src/weakLoadURL.js
+++ b/src/weakLoadURL.js
@@ -21,9 +21,6 @@ export default async function weakLoadURL(url, overrideOptions = {}) {
   this.abortController?.abort();
   this.abortController = abortController;
 
-  // Record node changes.
-  let switchResult = null;
-
   // Find path difference.
   const targetPath = parsedURL.pathname + parsedURL.search;
   const currentPath = this.location.pathname + this.location.search;
@@ -33,15 +30,15 @@ export default async function weakLoadURL(url, overrideOptions = {}) {
     if (window.location.href !== parsedURL.href) {
       window.history.pushState({}, document.title, parsedURL.href);
     }
+    await this.preparePage(null, overrideOptions);
   } else {
     // Fetch and switch on different path.
-    switchResult = await this.switchDOM(url, overrideOptions);
+    await this.switchDOM(url, overrideOptions);
   }
 
   // Update Pjax location and prepare the page.
   this.history.pull();
   this.location.href = window.location.href;
-  await this.preparePage(switchResult, overrideOptions);
 
   // Finish, remove abort controller.
   this.abortController = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* `pjax:complete` and `pjax:success` events fire before the page preparation (`preparePage.js`, mainly includes script execution and page scroll), mismatching original Pjax's behaviour and making it hard to track when the page has prepared.
* Enrich each event's details.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
