### PR TITLE
Add form submit support in default trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Pjax fetches the new content, switches parts of your page, updates the URL, exec
 
 ## How Pjax Works
 
-1. Listen to every trigger of anchor elements.
+1. Listen to simple redirections.
 2. Fetch the target page via `fetch`.
 3. Render the DOM tree using [`DOMParser`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser).
 4. Check if every defined selector selects the same amount of elements in current DOM and the new DOM.
@@ -170,7 +170,7 @@ When instantiating `Pjax`, you can pass options into the constructor as an objec
 
 ```js
 const pjax = new Pjax({
-  // default value, listens on all <a>
+  // default value, listens on all links and forms
   defaultTrigger: true,
   selectors: [
     'title',
@@ -181,11 +181,11 @@ const pjax = new Pjax({
 });
 ```
 
-This will enable Pjax on all links, and designate the part to replace using CSS selectors `'title', '.the-header', '.the-content', '.the-sidebar'`.
+This will enable Pjax on all links and forms, and designate the part to replace using CSS selectors `'title', '.the-header', '.the-content', '.the-sidebar'`.
 
 In some cases, you might want to only target some specific elements or specific moments to apply Pjax behavior. In that case:
 
-1. Set `defaultTrigger` to `false`. This will make Pjax not listen to link (`<a>` or `<area>` element) click and keyup events.
+1. Set `defaultTrigger` to `false`.
 2. Use `loadURL` method of the Pjax instance to let Pjax handle the navigation on your demand.
 
 ```js
@@ -267,6 +267,21 @@ Pjax.reload();
 ```
 
 ## Options
+
+### `defaultTrigger` (Boolean, default: `true`)
+
+When set to `false`, disable the default Pjax trigger.
+
+The default trigger alters these redirections:
+
+- Activations of `<a>` and `<area>` that targets a link within the same origin.
+- Submissions of `<form>` that *simply redirects* to a link within the same origin.
+
+Technically, a submission does a *simple redirection* when its:
+
+- Enctype matches `application/x-www-form-urlencoded`.
+- Target browsing context matches the form's one.
+- Method matches `get`.
 
 ### `selectors` (Array, default: `['title', '.pjax']`)
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ The default trigger alters these redirections:
 
 Technically, a submission does a *simple redirection* when its:
 
-- Enctype matches `application/x-www-form-urlencoded`.
-- Target browsing context matches `_self`.
-- Method matches `get`.
+- enctype matches `application/x-www-form-urlencoded`.
+- target browsing context matches `_self`.
+- method matches `get`.
 
 ### `selectors` (Array, default: `['title', '.pjax']`)
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ The default trigger alters these redirections:
 Technically, a submission does a *simple redirection* when its:
 
 - Enctype matches `application/x-www-form-urlencoded`.
-- Target browsing context matches the form's one.
+- Target browsing context matches `_self`.
 - Method matches `get`.
 
 ### `selectors` (Array, default: `['title', '.pjax']`)

--- a/src/utils/DefaultTrigger.js
+++ b/src/utils/DefaultTrigger.js
@@ -107,6 +107,8 @@ export default class DefaultTrigger {
       if (!link) return;
       this.onLinkOpen(event, link);
     });
+
+    // Lacking browser compatibility and small polyfill. - August 2, 2021
     if ('SubmitEvent' in window) {
       document.addEventListener('submit', this.onFormSubmit.bind(this));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Discussed in #69 .
[SubmitEvent API](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent) is used to find the form submitter button without using those unreliable or slow methods.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
