### PR TITLE
Avoid write to session storage when init

### DIFF
--- a/src/libs/LazyHistory/index.ts
+++ b/src/libs/LazyHistory/index.ts
@@ -25,14 +25,14 @@ declare module LazyHistory {
 
 class LazyHistory {
   /**
+   * Used to generate unique keys.
+   */
+  private count: number = 0;
+
+  /**
    * The prefix of the generated key.
    */
   idPrefix: string;
-
-  /**
-   * Used to generate unique keys.
-   */
-  count: number = 0;
 
   /**
    * The key used in `window.history.state`.
@@ -42,33 +42,33 @@ class LazyHistory {
   /**
    * The session key reflecting the current state.
    */
-  sessionKey: string;
+  sessionKey!: string;
 
   /**
    * The current state.
    */
-  state: LazyHistory.State;
+  state!: LazyHistory.State;
 
   constructor(idPrefix: string, historyKey: string = idPrefix) {
     this.idPrefix = idPrefix;
     this.historyKey = historyKey;
 
     // Initialize current history entry.
-    window.history.replaceState(this.#sign(), document.title);
+    window.history.replaceState(this.sign(), document.title);
   }
 
   /**
    * Save current state to session storage.
    */
-  #save() {
+  private save() {
     window.sessionStorage.setItem(this.sessionKey, JSON.stringify(this.state));
   }
 
   /**
    * Prepare a new session key and attach to current or given state.
    */
-  #sign(state: LazyHistory.State = window.history.state): LazyHistory.SignedState {
-    this.#save();
+  private sign(state: LazyHistory.State = window.history.state): LazyHistory.SignedState {
+    if (this.count > 0) this.save();
 
     // Generate a new key.
     const sessionKey = `${this.idPrefix}_${this.count}`;
@@ -90,19 +90,19 @@ class LazyHistory {
    * Push to history entry.
    */
   push(state: LazyHistory.State, title: string, url: string) {
-    window.history.pushState(this.#sign(state), title, url);
+    window.history.pushState(this.sign(state), title, url);
   }
 
   /**
    * Keep up with current browser history entry.
    */
   pull() {
-    this.#save();
+    this.save();
 
     const sessionKey = window.history.state?.[this.historyKey];
     if (!sessionKey) {
       // Initialize if haven't.
-      window.history.replaceState(this.#sign(), document.title);
+      window.history.replaceState(this.sign(), document.title);
     } else {
       this.sessionKey = sessionKey;
       const savedState = window.sessionStorage.getItem(sessionKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In LazyHistory lib,
- Fix `undefined` writing to session storage,
- Adapt strict TypeScript,
- Reorder class properties for readability,
- Use `private` field instead of ES `#` for readability and smaller bundle size.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
