### PR TITLE
Simplify history state storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,13 @@ export interface SwitchesResult {
   focusCleared: boolean;
 }
 
-export interface HistoryState {
-  [key: string]: unknown;
-  scrollPos?: [number, number];
+interface State {
+  scrollPos: [number, number];
 }
 
 export interface History {
+  state: State | null;
   pull(): void;
-  state: HistoryState;
 }
 
 export interface EventDetail {
@@ -110,11 +109,8 @@ export class Pjax {
       if (event.state === null) return;
 
       const overrideOptions: Partial<Options> = {};
-      if (this.options.scrollRestoration) {
-        const { scrollPos } = this.history.state;
-        if (scrollPos) {
-          overrideOptions.scrollTo = this.history.state.scrollPos;
-        }
+      if (this.options.scrollRestoration && this.history.state) {
+        overrideOptions.scrollTo = this.history.state.scrollPos;
       }
 
       this.load(window.location.href, overrideOptions).catch(() => {});
@@ -122,7 +118,9 @@ export class Pjax {
   }
 
   storeScrollPosition(): void {
-    this.history.state.scrollPos = [window.scrollX, window.scrollY];
+    this.history.state = {
+      scrollPos: [window.scrollX, window.scrollY],
+    };
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current LazyHistory API is a mess. Rewrite it and the new one looks like this:

In `window.history.state`:
```js
{
  ...others,
  pjax: 1, // The index of current Pjax state in session storage
}
```

In `window.sessionStorage.getItem('pjax')` (parsed):
```js
[
  {"scrollPos": [0,535.2000122070312]},
  {"scrollPos": [0,280.79998779296875]}, // Current Pjax state
  {"scrollPos": [0,106.4000015258789]},
]
```

LazyHistory lib is used to store scroll position.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
