### PR TITLE
Conform with standard History API

### DIFF
--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -83,7 +83,7 @@ export default async function preparePage(
     // Scroll.
     if (parsedScrollTo) window.scrollTo(parsedScrollTo[0], parsedScrollTo[1]);
 
-    // Set history title for Safari and future changes to History API.
+    // Set history state title for Safari.
     window.history.replaceState(window.history.state, document.title);
   }
 }

--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -82,5 +82,8 @@ export default async function preparePage(
 
     // Scroll.
     if (parsedScrollTo) window.scrollTo(parsedScrollTo[0], parsedScrollTo[1]);
+
+    // Set history title for Safari and future changes to History API.
+    window.history.replaceState(window.history.state, document.title);
   }
 }

--- a/src/switchDOM.ts
+++ b/src/switchDOM.ts
@@ -39,18 +39,18 @@ export default async function switchDOM(
       });
     eventDetail.response = response;
 
-    // Switch before changing URL.
+    // Push history state. Preserve hash as the fetch discards it.
+    const newLocation = new URL(response.url);
+    newLocation.hash = new URL(request.url).hash;
+    if (window.location.href !== newLocation.href) {
+      window.history.pushState(null, '', newLocation.href);
+    }
+
+    // Switch elements.
     const newDocument = new DOMParser().parseFromString(await response.text(), 'text/html');
     eventDetail.switches = switches;
     const switchesResult = await switchNodes(newDocument, { selectors, switches, signal });
     eventDetail.switchesResult = switchesResult;
-
-    // Update window location. Preserve hash as the fetch discards it.
-    const newLocation = new URL(response.url);
-    newLocation.hash = new URL(request.url).hash;
-    if (window.location.href !== newLocation.href) {
-      window.history.pushState({}, document.title, newLocation.href);
-    }
 
     // Simulate initial page load.
     await this.preparePage(switchesResult, overrideOptions);

--- a/src/weakLoad.ts
+++ b/src/weakLoad.ts
@@ -30,7 +30,7 @@ export default async function weakLoad(
     if (targetPath === currentPath) {
       // pushState on different hash.
       if (window.location.hash !== parsedURL.hash) {
-        window.history.pushState({}, document.title, parsedURL.href);
+        window.history.pushState(null, '', parsedURL.href);
       }
       await this.preparePage(null, overrideOptions);
       switchDOM = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The initial value of `window.history.state` is `null`.
- `replaceState` and `pushState` make no use of "title" parameter in HTML Standard.
- Safari uses the title parameter to present the name of the history state in places like back button dropdown, and if we pass empty strings, Safari uses unlovely raw URLs. — Set the title of current history state at the end of preparePage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
