### PR TITLE
Remove named Pjax export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint": "^7.26.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-airbnb-typescript": "^13.0.0",
-        "eslint-plugin-import": "^2.23.2",
+        "eslint-plugin-import": "^2.24.1",
         "eslint-plugin-jest": "^24.4.0",
         "jest": "^27.0.1",
         "jest-environment-jsdom": "^27.0.1",
@@ -4713,9 +4713,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.812",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.812.tgz",
-      "integrity": "sha512-7KiUHsKAWtSrjVoTSzxQ0nPLr/a+qoxNZwkwd9LkylTOgOXSVXkQbpIVT0WAUQcI5gXq3SwOTCrK+WfINHOXQg==",
+      "version": "1.3.813",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
+      "integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4729,6 +4729,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -5760,9 +5766,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -11183,12 +11189,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -16082,15 +16082,21 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.812",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.812.tgz",
-      "integrity": "sha512-7KiUHsKAWtSrjVoTSzxQ0nPLr/a+qoxNZwkwd9LkylTOgOXSVXkQbpIVT0WAUQcI5gXq3SwOTCrK+WfINHOXQg==",
+      "version": "1.3.813",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
+      "integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
       "dev": true
     },
     "emittery": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
       "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "emojis-list": {
@@ -16882,9 +16888,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -21012,14 +21018,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        }
       }
     },
     "string.prototype.trimend": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "^7.26.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^13.0.0",
-    "eslint-plugin-import": "^2.23.2",
+    "eslint-plugin-import": "^2.24.1",
     "eslint-plugin-jest": "^24.4.0",
     "jest": "^27.0.1",
     "jest-environment-jsdom": "^27.0.1",

--- a/src/__mocks__/index.ts
+++ b/src/__mocks__/index.ts
@@ -1,4 +1,5 @@
-import type { Pjax, Options } from '..';
+import type Pjax from '..';
+import type { Options } from '..';
 
 export default class MockedPjax implements Pjax {
   history!: Pjax['history'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export interface EventDetail {
   error?: unknown;
 }
 
-export class Pjax {
+class Pjax {
   static switches = Switches;
 
   static reload(): void {

--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -1,4 +1,5 @@
-import type { Pjax, Options, SwitchesResult } from '.';
+import type Pjax from '.';
+import type { Options, SwitchesResult } from '.';
 
 import executeScripts from './libs/executeScripts';
 

--- a/src/switchDOM.ts
+++ b/src/switchDOM.ts
@@ -1,4 +1,5 @@
-import type { Pjax, Options, EventDetail } from '.';
+import type Pjax from '.';
+import type { Options, EventDetail } from '.';
 import switchNodes from './utils/switchNodes';
 
 export default async function switchDOM(

--- a/src/utils/DefaultTrigger.ts
+++ b/src/utils/DefaultTrigger.ts
@@ -1,4 +1,4 @@
-import type { Pjax } from '..';
+import type Pjax from '..';
 import Submission from '../libs/Submission';
 
 type Link = HTMLAnchorElement | HTMLAreaElement;

--- a/src/weakLoad.ts
+++ b/src/weakLoad.ts
@@ -1,4 +1,5 @@
-import type { Pjax, Options } from '.';
+import type Pjax from '.';
+import type { Options } from '.';
 
 /**
  * Load a URL in Pjax way. Throw all errors.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Use eslint-plugin-import >= 2.24.1

Named Pjax export was used to avoid https://github.com/import-js/eslint-plugin-import/issues/2130 . Now they got it fixed in 2.24.1.

Removing it reduces bundle sizes, too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
