### PR TITLE
Added "response" event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ class Pjax {
   /**
    * Fire Pjax related events.
    */
-  fire(type: 'send' | 'error' | 'success' | 'complete', detail: EventDetail): void {
+  fire(type: 'send' | 'response' | 'error' | 'success' | 'complete', detail: EventDetail): void {
     const event = new CustomEvent(`pjax:${type}`, {
       bubbles: true,
       cancelable: false,

--- a/src/switchDOM.ts
+++ b/src/switchDOM.ts
@@ -51,6 +51,8 @@ export default async function switchDOM(
       window.history.pushState(null, '', newLocation.href);
     }
 
+    this.fire('response', eventDetail);
+    
     // Switch elements.
     const newDocument = new DOMParser().parseFromString(await response.text(), 'text/html');
     eventDetail.switches = switches;


### PR DESCRIPTION
Added an event after the response is received and before the actual dom changes.
This is very useful in order allow initialization of JavaScript components that needs to occur before the dom changes.
I also suggest adding even more, since events are our only way to interact with this plugin functionality.
for instance view the events available here:
https://falsandtru.github.io/pjax-api/api/event/

## Types of changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ X ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
