### PR TITLE
Use case-insensitive match to parse script type

### DIFF
--- a/src/libs/executeScripts/Script.ts
+++ b/src/libs/executeScripts/Script.ts
@@ -44,7 +44,7 @@ export default class Script {
     if (!scriptEle.hasAttribute('src') && !scriptEle.text) return;
 
     // Process type.
-    const typeString = scriptEle.type ? scriptEle.type.trim() : 'text/javascript';
+    const typeString = scriptEle.type ? scriptEle.type.trim().toLowerCase() : 'text/javascript';
     if (MIMETypes.includes(typeString)) {
       this.type = 'classic';
     } else if (typeString === 'module') {

--- a/test/libs/executeScripts/Script.test.ts
+++ b/test/libs/executeScripts/Script.test.ts
@@ -40,14 +40,16 @@ test.describe('script', () => {
   });
 
   test('normal module', () => {
-    const moduleScriptEle = document.createElement('script');
-    moduleScriptEle.text = '()';
-    moduleScriptEle.type = 'module';
+    ['module', 'modUle'].forEach((validModuleTypeStrings) => {
+      const moduleScriptEle = document.createElement('script');
+      moduleScriptEle.text = '()';
+      moduleScriptEle.type = validModuleTypeStrings;
 
-    const moduleScript = new Script(moduleScriptEle);
-    expect(moduleScript.type).toBe('module');
-    expect(moduleScript.evaluable).toBe(true);
-    expect(moduleScript.blocking).toBe(false);
+      const moduleScript = new Script(moduleScriptEle);
+      expect(moduleScript.type).toBe('module');
+      expect(moduleScript.evaluable).toBe(true);
+      expect(moduleScript.blocking).toBe(false);
+    });
   });
 
   test('normal internal', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As in
[script's `type` attribute | HTML Standard](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type) and
[a JavaScript MIME type essence match | MIME Sniffing Standard](https://mimesniff.spec.whatwg.org/#javascript-mime-type-essence-match).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires new tests.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
