### PR TITLE
Differentiate base URL from URL

### DIFF
--- a/src/libs/Submission/index.ts
+++ b/src/libs/Submission/index.ts
@@ -82,7 +82,7 @@ class Submission {
    */
   getRequestInfo(): RequestInfo | null {
     const action = this.getAttribute('action');
-    const actionURL = new URL(action, document.URL);
+    const actionURL = new URL(action, document.baseURI);
 
     // Only 'http' and 'https' schemes are supported.
     if (!/^https?:$/.test(actionURL.protocol)) return null;

--- a/src/libs/executeScripts/Script.ts
+++ b/src/libs/executeScripts/Script.ts
@@ -54,7 +54,7 @@ export default class Script {
 
       try {
         // eslint-disable-next-line no-new
-        new URL(src, document.URL);
+        new URL(src, document.baseURI);
       } catch {
         return;
       }

--- a/src/weakLoad.ts
+++ b/src/weakLoad.ts
@@ -21,7 +21,7 @@ export default async function weakLoad(
    * The URL object of the target resource.
    * Used to identify fragment navigations.
    */
-  const url = new URL(typeof requestInfo === 'string' ? requestInfo : requestInfo.url, document.URL);
+  const url = new URL(typeof requestInfo === 'string' ? requestInfo : requestInfo.url, document.baseURI);
   const path = url.pathname + url.search;
   const currentPath = this.location.pathname + this.location.search;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* The standard algorithm to [parse a URL](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url) uses the "base URL" of a document. `Submission` lib, `Script` lib, and `weakLoad` func mistakenly use the "URL" of the document.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unfortunately, there's no plan for `Submission` lib and `weakLoad` func test cases, yet. `Script` lib uses `document.baseURI` in a way indistinguishable from using any absolute URL.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
