### PR TITLE
Preserve request referrer and referrerPolicy

### DIFF
--- a/test/switchDOM.test.ts
+++ b/test/switchDOM.test.ts
@@ -111,6 +111,26 @@ test.describe('switch DOM', () => {
     expect(sentHeaders.get('X-Pjax-Selectors')).toBe(JSON.stringify(pjax.options.selectors));
   });
 
+  test('preserve referrer and referrerPolicy', async ({ pjax }) => {
+    let sentReferrer = '';
+    let sentReferrerPolicy: ReferrerPolicy = '';
+    onfetch('/referrer')
+      .reply((request) => {
+        sentReferrer = request.referrer;
+        sentReferrerPolicy = request.referrerPolicy;
+        return null;
+      });
+
+    const request = new Request('/referrer', {
+      referrer: '/specified-referrer',
+      referrerPolicy: 'no-referrer-when-downgrade',
+    });
+    await pjax.switchDOM(request);
+
+    expect(new URL(sentReferrer).pathname).toBe('/specified-referrer');
+    expect(sentReferrerPolicy).toBe('no-referrer-when-downgrade');
+  });
+
   test('cache mode', async ({ pjax }) => {
     let requestCache = '';
     onfetch('/cache-mode')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In [`new Request(input, init)` constructor steps | Fetch Standard](https://fetch.spec.whatwg.org/#dom-request),

step 13 discards the original request's referrer and referrer policy when _init_ is not empty,

> If _init_ is not empty, then:
> 1. If _request_’s mode is "`navigate`", then set it to "`same-origin`".
> 2. Unset _request_’s reload-navigation flag.
> 3. Unset _request_’s history-navigation flag.
> 4. Set _request_’s referrer to "`client`"
> 5. Set _request_’s referrer policy to the empty string.
>
> **Note**
>
> _This is done to ensure that when a service worker "redirects" a request, e.g., from an image in a cross-origin style sheet, and makes modifications, it no longer appears to come from the original source (i.e., the cross-origin style sheet), but instead from the service worker that "redirected" the request. This is important as the original source might not even be able to generate the same kind of requests as the service worker. Services that trust the original source could therefore be exploited were this not done, although that is somewhat farfetched._

we can reset referrer via step 14,

> If _init_["`referrer`"] exists, then:
> 1. Let _referrer_ be _init_["`referrer`"].
> ... (steps to set _request_'s referrer to a parsed _referrer_)

and referrer policy via step 15,

> If _init_["`referrerPolicy`"] exists, then set _request_’s referrer policy to it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires new tests.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
