### PR TITLE
Support rel and referrer policy attributes

### DIFF
--- a/src/utils/DefaultTrigger.ts
+++ b/src/utils/DefaultTrigger.ts
@@ -63,8 +63,8 @@ export default class DefaultTrigger {
     if (referrerPolicy !== undefined) requestInit.referrerPolicy = referrerPolicy as ReferrerPolicy;
 
     /**
-     * Use no-referrer if specified in the link types.
-     * Not reading from `.relList` here as it is not landed for forms yet.
+     * Use no referrer if specified in the link types.
+     * Not reading from `.relList` here as browsers haven't shipped it for forms yet.
      * @see [Add &lt;form rel&gt; initial compat data · mdn/browser-compat-data]{@link https://github.com/mdn/browser-compat-data/pull/9130}
      */
     if (subject.getAttribute('rel')?.split(/\s+/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The request to send by an element typically relies on two attributes, `rel` and `referrerpolicy`:
* For `<a>` and `<area>` activations: [follow the hyperlink | HTML Standard](https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2).
* For `<form>` submissions: [plan to navigate | HTML Standard](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#plan-to-navigate).

This PR adds support for this two attributes to Pjax's default trigger.

You may have noticed the spec didn't mention `referrerpolicy` attribute on `<form>`s. Yes, it hasn't achieve a standard, yet. I still add its support in Pjax, cause:
1. WHATWG members consider the lacking of this attribute an "oversight" and tend to add the support. See https://github.com/whatwg/html/issues/4320.
2. No reasonable case conflicts with this attribute. (Even rare within very non-conforming plugins / websites.)
3. Bypassing this for `<form>`s requires a more complex algorithm.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sorry, I don't have a plan for adding default trigger's test cases, yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires new tests.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
