### PR TITLE
Simplify script execution

### DIFF
--- a/test/libs/executeScripts/Script.test.ts
+++ b/test/libs/executeScripts/Script.test.ts
@@ -28,17 +28,6 @@ test.describe('script', () => {
     expect(new Script(noModuleScriptEle).evaluable).toBe(false);
   });
 
-  test('with invalid src attribute', () => {
-    const srcInvalidScriptEle = document.createElement('script');
-    srcInvalidScriptEle.text = 'somethingMakeItNotEmpty()';
-
-    ['', 'https://'].forEach((invalidValue) => {
-      srcInvalidScriptEle.setAttribute('src', invalidValue);
-
-      expect(new Script(srcInvalidScriptEle).evaluable).toBe(false);
-    });
-  });
-
   test('normal module', () => {
     ['module', 'modUle'].forEach((validModuleTypeStrings) => {
       const moduleScriptEle = document.createElement('script');
@@ -112,10 +101,10 @@ test.describe('script', () => {
                 window.dispatchEvent(new Event('${uid}'));
               }
             `;
+            onfetch(`/${uid}`).reply(scriptEleText).persist();
             const scriptEle = document.createElement('script');
             scriptEle.id = uid;
             if (scriptType === 'external') {
-              onfetch(uid).reply(scriptEleText);
               scriptEle.src = uid;
             } else {
               scriptEle.text = scriptEleText;

--- a/test/libs/executeScripts/executeScripts.test.ts
+++ b/test/libs/executeScripts/executeScripts.test.ts
@@ -26,16 +26,13 @@ test.describe('execute scripts', () => {
     window.addEventListener(uid, listener);
 
     await executeScripts(container.querySelectorAll('script'));
-    expect(count)
-      .toBe(2);
+    expect(count).toBe(2);
 
     await executeScripts(container.children as HTMLCollectionOf<HTMLScriptElement>);
-    expect(count)
-      .toBe(4);
+    expect(count).toBe(4);
 
     await executeScripts(new Set(container.children as HTMLCollectionOf<HTMLScriptElement>));
-    expect(count)
-      .toBe(6);
+    expect(count).toBe(6);
 
     window.removeEventListener(uid, listener);
   });
@@ -43,14 +40,14 @@ test.describe('execute scripts', () => {
   test('ignore non-blocking execution time', async ({ uid }) => {
     // Lock the time.
     const clock = FakeTimers.install();
-    onfetch('/async.js')
+    onfetch('/delay.js')
       .delay(100)
       .reply();
 
     const container = document.createElement('div');
     container.innerHTML = `
       <script>window.dispatchEvent(new Event('${uid}'))</script>
-      <script async src="/async.js"></script>
+      <script async src="/delay.js"></script>
       <script>window.dispatchEvent(new Event('${uid}'))</script>
     `;
 
@@ -61,8 +58,7 @@ test.describe('execute scripts', () => {
     window.addEventListener(uid, listener);
 
     await executeScripts(container.children as HTMLCollectionOf<HTMLScriptElement>);
-    expect(count)
-      .toBe(2);
+    expect(count).toBe(2);
 
     window.removeEventListener(uid, listener);
     clock.uninstall();
@@ -73,19 +69,15 @@ test.describe('execute scripts', () => {
     onfetch('/blocking.js')
       .reply(scriptText(' external blocking'));
     onfetch('/async.js')
-      .times(6)
-      .reply(scriptText(' external async'));
+      .reply(scriptText(' external async'))
+      .twice();
 
     const container = document.createElement('div');
     container.innerHTML = `
       <script async src="/async.js"></script>
-      <script defer src="/async.js"></script>
       <script>${scriptText('execute')}</script>
-      <script async src="/async.js"></script>
       <script defer src="/async.js"></script>
       <script src="/blocking.js"></script>
-      <script async src="/async.js"></script>
-      <script defer src="/async.js"></script>
       <script>${scriptText(' done')}</script>
     `;
 
@@ -94,6 +86,38 @@ test.describe('execute scripts', () => {
       .resolves.not.toThrow();
     expect(document.body.className.replace(/ external async/g, ''))
       .toBe('execute external blocking done');
+  });
+
+  test('externals being fetched in parallel and keep original order', async () => {
+    const eventTarget = new EventTarget();
+    onfetch('/former.js')
+      .reply(new Promise<string>((resolve) => {
+        eventTarget.addEventListener('latter-fetched', () => {
+          resolve(scriptText(' former'));
+        });
+      }));
+    onfetch('/latter.js')
+      .reply(() => {
+        window.setTimeout(() => {
+          eventTarget.dispatchEvent(new Event('latter-fetched'));
+        });
+        return scriptText(' latter');
+      });
+
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <script>${scriptText('start')}</script>
+      <script src="/former.js"></script>
+      <script>${scriptText(' inline')}</script>
+      <script src="/latter.js"></script>
+      <script>${scriptText(' done')}</script>
+    `;
+
+    document.body.className = '';
+    await expect(executeScripts(container.children as HTMLCollectionOf<HTMLScriptElement>))
+      .resolves.not.toThrow();
+    expect(document.body.className)
+      .toBe('start former inline latter done');
   });
 
   test('integrated with given signal', async ({ uid }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Simplify
  * Remove `src` validity checks. \
     `src` validity check improves script execution performance **only when** there's **many** script elements with **invalid** `src` attribute. In **most** cases, it just **slows** the process and increases the bundles' size.
  * Use `defer` IDL attribute instead of a `getAttribute('defer')`. \
    `defer` IDL attribute [**reflects**](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect) the `defer` content attribute. And it's **shorter and quicker**.
  * Remove the meaningless `defer = false` when preparing a new <script>. \
    Initially, I write it for JSDOM. Now the test cases run in real browsers and I don't see any of them (`chromium`, `firefox`, `webkit`) needs this.
  * Run `async = false` before cloning the attributes of the original script to avoid attribute checks. \
    Setting `async` is to unset the ["non-blocking"](https://html.spec.whatwg.org/multipage/scripting.html#non-blocking) flag, which is not automatically unset on `<script>`s created by scripts. Documented in [the async IDL attribute | HTML Standard](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-async).
- Add "externals being fetched in parallel and keep original order" test in executeScripts lib.
- Add a note about why we use `document.contains` instead of `.isConnected`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
pw-test "test/libs/executeScripts/*.test.ts" --sw test/sw.ts --browser chromium
pw-test "test/libs/executeScripts/*.test.ts" --sw test/sw.ts --browser firefox
pw-test "test/libs/executeScripts/*.test.ts" --sw test/sw.ts --browser webkit
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no bug fix and new feature but improvements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires new tests.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
